### PR TITLE
24 test split pool function

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -65,6 +65,7 @@ export class Pool {
     const keep: SuiObjectRef[] = [];
     const give: SuiObjectRef[] = [];
 
+    outside:  // label to specify the null break statement
     while (this._objects.length !== 0) {
       switch (pred(this._objects.at(-1))) {
         case true:
@@ -74,7 +75,7 @@ export class Pool {
           keep.push(this._objects.pop()!);
           continue;
         case null:
-          break;
+          break outside;
       }
     }
     this.objects.push(...keep);

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -106,9 +106,7 @@ describe('✂️ Pool splitting', () => {
           .toEqual(num_objects_before_split);
   });
 
-  // FIXME - times out when creating a pool 
-  // Currently not executed in the test suite. To include it, use "it" instead of "xit"
-  xit('splits a pool using an <always-null> predicate', async () => {
+  it('splits a pool using an <always-null> predicate', async () => {
     /* 
     Create a pool 
     */


### PR DESCRIPTION
Created a test suite for `predicates` that return only `true`, `false` and `null`.

⚠️ The predicate that always returns `null` for some reason gets stuck ~~in an infinite loop~~. 
~~After some debugging it looks like the program gets stuck [while trying to fetch the owned objects of the client](https://github.com/MystenLabs/coin_management_system/blob/2ba33448648114a9fd178728bd8e610073b86aa0/src/pool.ts#L41C1-L42C1).~~
Update: It was an infinite loop as it was assumed initially. ✅ 

Run tests with: `node_modules/.bin/jest --verbose`