### PR TITLE
Update tsconfig.json to compile to js files too

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "composite": false,
-    "emitDeclarationOnly": true,
     // output .js.map sourcemap files for consumers
     "sourceMap": true
   },


### PR DESCRIPTION
To compile the TypeScript code into JavaScript files as well, we should set "emitDeclarationOnly" option to false or simply remove it the default value is false.

@teohaik after merging please create a new release since with the current version we can't import any modules. 